### PR TITLE
Change to corruptAlertThreshold to match NeDB options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "4.8"
-  - "6.0"
-  - "8.0"
+  - "4"
+  - "6"
+  - "8"
 before_install:
   - npm update -g npm
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4.1"
+  - "4.8"
+  - "6.0"
+  - "8.0"
 before_install:
   - npm update -g npm
   - npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ _**ONLY applies when your NeDB datastore is file-persisted!**_
 For more details about the underlying `beforeDeserialization` option, please read about it in the [NeDB documentation][].
 
 
-#### `corruptAfterThreshold`
+#### `corruptAlertThreshold`
 
 _Optional._ **[Number]** NeDB will refuse to start if more than this percentage of the datafile is corrupt. Valid values must be a number between `0` (0%) and `1` (100%). A value of `0` means you do NOT tolerate any corruption, `1` means you do not care about corruption. NeDB uses a default value of `0.1` (10%).
 
 _**ONLY applies when your NeDB datastore is file-persisted!**_
 
-For more details about the underlying `corruptAfterThreshold` option, please read about it in the [NeDB documentation][].
+For more details about the underlying `corruptAlertThreshold` option, please read about it in the [NeDB documentation][].
 
 
 #### `autoCompactInterval`

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function( connect ) {
    * @param {String}   options.filename               Relative file path where session data will be persisted; if none, a default of 'data/sessions.db' will be used.
    * @param {Function} options.afterSerialization     Optional serialization callback invoked before writing to file, e.g. for encrypting data.
    * @param {Function} options.beforeDeserialization  Optional deserialization callback invoked after reading from file, e.g. for decrypting data.
-   * @param {Number}   options.corruptAfterThreshold  Optional threshold after which an error is thrown if too much data read from file is corrupt. Default: 0.1 (10%).
+   * @param {Number}   options.corruptAlertThreshold  Optional threshold after which an error is thrown if too much data read from file is corrupt. Default: 0.1 (10%).
    * @param {Number}   options.autoCompactInterval    Optional interval in milliseconds at which to auto-compact file-based datastores. Valid range is 5000ms to 1 day. Pass `null` to disable.
    * @param {Function} options.onload                 Optional callback to be invoked when the datastore is loaded and ready.
    */
@@ -77,7 +77,7 @@ module.exports = function( connect ) {
       options.filename = null;
       options.afterSerialization = null;
       options.beforeDeserialization = null;
-      options.corruptAfterThreshold = undefined;
+      options.corruptAlertThreshold = undefined;
       options.autoCompactInterval = null;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nedb-session-store",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A session store implementation for Connect & Express backed by an NeDB datastore (either in-memory or file-persisted)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Rename `corruptAfterThreshold` to be `corruptAlertThreshold` to match
NeDB options. See:
https://github.com/louischatriot/nedb#creatingloading-a-database
Fix #1